### PR TITLE
Add branch store cloning utilities

### DIFF
--- a/store/types/store.go
+++ b/store/types/store.go
@@ -295,6 +295,9 @@ type CacheWrap interface {
 	// Write syncs with the underlying store.
 	Write()
 
+	// Discard clears the pending write set without applying it to the parent store.
+	Discard()
+
 	// CacheWrap recursively wraps again.
 	CacheWrap() CacheWrap
 
@@ -308,6 +311,15 @@ type CacheWrapper interface {
 
 	// CacheWrapWithTrace branches a store with tracing enabled.
 	CacheWrapWithTrace(w io.Writer, tc TraceContext) CacheWrap
+}
+
+// BranchStore represents a cache store that can be cloned and restored.
+type BranchStore interface {
+	// Clone returns a copy-on-write snapshot of the store.
+	Clone() BranchStore
+
+	// Restore replaces the store's contents with that of the given snapshot.
+	Restore(BranchStore)
 }
 
 func (cid CommitID) IsZero() bool {


### PR DESCRIPTION
## Summary
- extend CacheWrap interface with `Discard`
- introduce `BranchStore` interface
- implement `Clone`, `Restore`, and `Discard` for cachekv.Store
- implement `Clone`, `Restore`, `Discard`, `RunAtomic` for cachemulti.Store

## Testing
- `go test ./...` *(fails: forbidden to download modules)*

------
https://chatgpt.com/codex/tasks/task_b_68523ba7f234832b8e500472b15075d3